### PR TITLE
Log room construction ascii representation

### DIFF
--- a/ROOM_DEBUG.md
+++ b/ROOM_DEBUG.md
@@ -1,0 +1,82 @@
+# Room Construction Debugging
+
+This game includes a room debugging system that automatically logs ASCII representations of rooms when they are first rendered.
+
+## Features
+
+- **Automatic Logging**: Rooms are automatically logged the first time they are constructed
+- **ASCII Representation**: Each room is displayed as a 2-digit tile index grid with comma-separated values per row
+- **Rotating Log Files**: Daily log rotation with files named `room_debug_YYYY-MM-DD.log`
+- **One-time Logging**: Each room is only logged once per session to avoid spam
+- **Thread-safe**: Safe for concurrent room creation
+
+## Log Format
+
+Each room log entry includes:
+- Room name/zone ID
+- Timestamp of first render
+- Room dimensions (width x height in tiles)
+- ASCII grid representation using 2-digit tile indices
+- Empty tiles are represented as `99`
+
+## Example Log Entry
+
+```
+=== ROOM DEBUG: main ===
+Timestamp: 2025-08-01 23:32:33
+Room Dimensions: 80x60 tiles
+ASCII Representation (2-digit tile indices):
+99,99,99,99,99,99,99,99,99,99
+99,99,99,99,99,99,99,99,99,99
+99,99,05,06,07,99,99,99,99,99
+01,02,03,01,02,99,99,99,99,99
+=== END ROOM DEBUG ===
+```
+
+## Log Location
+
+- Logs are stored in the `log/` directory
+- Files are named `room_debug_YYYY-MM-DD.log`
+- Each day gets its own log file
+
+## Implementation
+
+The debugging system consists of:
+- `world/debug.go` - Core debugging functionality
+- `RoomDebugger` singleton - Manages logging state and file operations
+- `BaseRoom.LogRoomDebug()` - Helper method for any room type
+- Automatic integration in `SimpleRoom.buildRoom()`
+
+## Usage for Custom Rooms
+
+If you create custom room types, add this call at the end of your room construction:
+
+```go
+func (r *MyCustomRoom) buildRoom() {
+    // ... room construction logic ...
+    
+    // Debug: Log ASCII representation on first render
+    debugger := world.GetRoomDebugger()
+    debugger.LogRoomFirstRender(r.GetZoneID(), r.tileMap)
+}
+```
+
+Or use the helper method from BaseRoom:
+
+```go
+func (r *MyCustomRoom) buildRoom() {
+    // ... room construction logic ...
+    
+    // Debug: Log ASCII representation on first render
+    r.LogRoomDebug()
+}
+```
+
+## Maintenance
+
+The system includes automatic cleanup functionality to remove old log files. This can be called periodically:
+
+```go
+debugger := world.GetRoomDebugger()
+debugger.CleanupOldLogs(7) // Keep logs for 7 days
+```

--- a/log/room_debug_2025-08-01.log
+++ b/log/room_debug_2025-08-01.log
@@ -1,0 +1,25 @@
+=== ROOM DEBUG: test_room ===
+Timestamp: 2025-08-01 23:32:33
+Room Dimensions: 10x8 tiles
+ASCII Representation (2-digit tile indices):
+99,99,99,99,99,99,99,99,99,99
+99,99,99,99,99,99,99,99,99,99
+99,99,99,99,99,99,99,99,99,99
+99,99,99,99,99,99,99,99,99,99
+99,99,05,06,07,99,99,99,99,99
+99,99,99,99,99,99,99,99,99,99
+01,02,03,01,02,99,99,99,99,99
+99,99,99,99,99,99,99,99,99,99
+=== END ROOM DEBUG ===
+
+=== ROOM DEBUG: test_room_2 ===
+Timestamp: 2025-08-01 23:32:33
+Room Dimensions: 5x5 tiles
+ASCII Representation (2-digit tile indices):
+99,99,99,99,99
+99,99,99,99,99
+99,99,99,99,99
+99,99,99,99,99
+10,11,12,99,99
+=== END ROOM DEBUG ===
+

--- a/world/debug.go
+++ b/world/debug.go
@@ -1,0 +1,133 @@
+package world
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RoomDebugger handles room debugging output with rotating log files
+type RoomDebugger struct {
+	logDir       string
+	mutex        sync.Mutex
+	renderedRooms map[string]bool // Track which rooms have been logged
+}
+
+var debugger *RoomDebugger
+var once sync.Once
+
+// GetRoomDebugger returns a singleton instance of the room debugger
+func GetRoomDebugger() *RoomDebugger {
+	once.Do(func() {
+		debugger = &RoomDebugger{
+			logDir:        "log",
+			renderedRooms: make(map[string]bool),
+		}
+		// Ensure log directory exists
+		os.MkdirAll(debugger.logDir, 0755)
+	})
+	return debugger
+}
+
+// LogRoomFirstRender logs the ASCII representation of a room on its first render
+func (rd *RoomDebugger) LogRoomFirstRender(roomName string, tileMap *TileMap) {
+	rd.mutex.Lock()
+	defer rd.mutex.Unlock()
+
+	// Check if this room has already been logged
+	if rd.renderedRooms[roomName] {
+		return
+	}
+
+	// Mark this room as logged
+	rd.renderedRooms[roomName] = true
+
+	// Generate ASCII representation
+	asciiRep := rd.generateASCIIRepresentation(tileMap)
+
+	// Create log entry
+	logEntry := fmt.Sprintf("=== ROOM DEBUG: %s ===\n", roomName)
+	logEntry += fmt.Sprintf("Timestamp: %s\n", time.Now().Format("2006-01-02 15:04:05"))
+	logEntry += fmt.Sprintf("Room Dimensions: %dx%d tiles\n", tileMap.Width, tileMap.Height)
+	logEntry += "ASCII Representation (2-digit tile indices):\n"
+	logEntry += asciiRep
+	logEntry += "\n=== END ROOM DEBUG ===\n\n"
+
+	// Write to rotating log file
+	rd.writeToRotatingLog(logEntry)
+}
+
+// generateASCIIRepresentation creates an ASCII representation of the room
+// using 2-digit tile indices with comma separation per row
+func (rd *RoomDebugger) generateASCIIRepresentation(tileMap *TileMap) string {
+	var builder strings.Builder
+
+	for y := 0; y < tileMap.Height; y++ {
+		var rowValues []string
+		for x := 0; x < tileMap.Width; x++ {
+			tileIndex := tileMap.Tiles[y][x]
+			// Convert -1 (empty) to 99 for better visualization
+			if tileIndex == -1 {
+				rowValues = append(rowValues, "99")
+			} else {
+				rowValues = append(rowValues, fmt.Sprintf("%02d", tileIndex))
+			}
+		}
+		builder.WriteString(strings.Join(rowValues, ","))
+		if y < tileMap.Height-1 {
+			builder.WriteString("\n")
+		}
+	}
+
+	return builder.String()
+}
+
+// writeToRotatingLog writes the log entry to a rotating log file
+func (rd *RoomDebugger) writeToRotatingLog(entry string) {
+	// Create filename with current date for daily rotation
+	filename := fmt.Sprintf("room_debug_%s.log", time.Now().Format("2006-01-02"))
+	filepath := filepath.Join(rd.logDir, filename)
+
+	// Open file in append mode, create if it doesn't exist
+	file, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Printf("Error opening log file: %v\n", err)
+		return
+	}
+	defer file.Close()
+
+	// Write the log entry
+	if _, err := file.WriteString(entry); err != nil {
+		fmt.Printf("Error writing to log file: %v\n", err)
+	}
+}
+
+// CleanupOldLogs removes log files older than the specified number of days
+func (rd *RoomDebugger) CleanupOldLogs(daysToKeep int) {
+	rd.mutex.Lock()
+	defer rd.mutex.Unlock()
+
+	cutoff := time.Now().AddDate(0, 0, -daysToKeep)
+
+	files, err := os.ReadDir(rd.logDir)
+	if err != nil {
+		return
+	}
+
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), "room_debug_") && strings.HasSuffix(file.Name(), ".log") {
+			info, err := file.Info()
+			if err != nil {
+				continue
+			}
+
+			if info.ModTime().Before(cutoff) {
+				filepath := filepath.Join(rd.logDir, file.Name())
+				os.Remove(filepath)
+			}
+		}
+	}
+}

--- a/world/room.go
+++ b/world/room.go
@@ -374,3 +374,13 @@ func (br *BaseRoom) DrawTilesWithCamera(screen *ebiten.Image, spriteProvider fun
 		}
 	}
 }
+
+/*
+LogRoomDebug logs the ASCII representation of this room on first render.
+This method can be called by any room implementation to enable debugging.
+It will only log each room once per session.
+*/
+func (br *BaseRoom) LogRoomDebug() {
+	debugger := GetRoomDebugger()
+	debugger.LogRoomFirstRender(br.zoneID, br.tileMap)
+}

--- a/world/simple_room.go
+++ b/world/simple_room.go
@@ -170,6 +170,10 @@ func (sr *SimpleRoom) buildRoom() {
 	sr.tileMap.SetTile(roomWidth*29/100, roomHeight*55/100, TILE_FLOATING)
 	sr.tileMap.SetTile(roomWidth*63/100, roomHeight*52/100, TILE_FLOATING)
 	sr.tileMap.SetTile(roomWidth*79/100, roomHeight*48/100, TILE_FLOATING)
+	
+	// Debug: Log ASCII representation of room on first render
+	debugger := GetRoomDebugger()
+	debugger.LogRoomFirstRender(sr.GetZoneID(), sr.tileMap)
 }
 
 // createPlatform creates a floating platform at the specified position


### PR DESCRIPTION
Add room construction debugging to log ASCII representations of rooms to rotating files on first render.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f750490-d033-484d-b4d3-1453f1e40538">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f750490-d033-484d-b4d3-1453f1e40538">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>