### PR TITLE
Update debug menu with current room tile map

### DIFF
--- a/states/pause_state.go
+++ b/states/pause_state.go
@@ -67,8 +67,8 @@ func (p *PauseState) Update() error {
 	}
 	if inpututil.IsKeyJustPressed(ebiten.KeyS) {
 		// Open settings with current room data
-		if ingameState, ok := p.backgroundState.(*InGameState); ok && ingameState.GetCurrentRoom() != nil {
-			p.stateManager.ChangeState(NewSettingsStateFromPause(p.stateManager, ingameState.GetCurrentRoom(), p))
+		if ingameState, ok := p.backgroundState.(*InGameState); ok {
+			p.stateManager.ChangeState(NewSettingsStateFromPause(p.stateManager, ingameState, p))
 		}
 	}
 	if inpututil.IsKeyJustPressed(ebiten.KeyQ) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update debug tile menu to show live room map and improve tile info for easier debugging.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the debug tile menu displayed a static room. This PR modifies the `SettingsState` to dynamically fetch the current room from `InGameState` when accessed from the pause menu, ensuring the displayed tile map is always current. It also enhances the tile information display with decimal indices, improved coordinate formatting, and a live/static indicator for better in-game debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-c81a4be8-451d-4800-bb0b-12b3075c61d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c81a4be8-451d-4800-bb0b-12b3075c61d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>