### PR TITLE
Refactor sprite handling to use SpriteManager

### DIFF
--- a/engine/sprite_config.go
+++ b/engine/sprite_config.go
@@ -1,0 +1,49 @@
+package engine
+
+import (
+	"sword/resources/images"
+	"sword/resources/images/platformer"
+)
+
+// SpriteSheetConfig defines configuration for a sprite sheet.
+// ImageData contains the raw bytes for the sheet image.
+type SpriteSheetConfig struct {
+	Name       string
+	ImageData  []byte
+	TileWidth  int
+	TileHeight int
+}
+
+// SpriteSheetConfigs lists all sprite sheets to load at startup.
+var SpriteSheetConfigs = []SpriteSheetConfig{
+	{
+		Name:       "player_left",
+		ImageData:  platformer.Left_png,
+		TileWidth:  165,
+		TileHeight: 205,
+	},
+	{
+		Name:       "player_right",
+		ImageData:  platformer.Right_png,
+		TileWidth:  165,
+		TileHeight: 205,
+	},
+	{
+		Name:       "player_idle",
+		ImageData:  platformer.MainChar_png,
+		TileWidth:  165,
+		TileHeight: 205,
+	},
+	{
+		Name:       "background",
+		ImageData:  platformer.Background_png,
+		TileWidth:  1920,
+		TileHeight: 1080,
+	},
+	{
+		Name:       "forest",
+		ImageData:  images.ForestTiles_png,
+		TileWidth:  16,
+		TileHeight: 16,
+	},
+}

--- a/engine/sprite_helpers.go
+++ b/engine/sprite_helpers.go
@@ -12,15 +12,23 @@ func GetPlayerSprite(facing string) *ebiten.Image {
 	if GameConfig.UsePlaceholderSprites {
 		return GeneratePlayerPlaceholder()
 	}
-	
+
+	sm := GetSpriteManager()
+	var sheetName string
 	switch facing {
 	case "left":
-		return globalLeftSprite
+		sheetName = "player_left"
 	case "right":
-		return globalRightSprite
+		sheetName = "player_right"
 	default:
-		return globalIdleSprite
+		sheetName = "player_idle"
 	}
+
+	sprite := sm.GetTileByIndex(sheetName, 0)
+	if sprite == nil {
+		return GeneratePlayerPlaceholder()
+	}
+	return sprite
 }
 
 /*
@@ -31,10 +39,13 @@ func GetEnemySprite() *ebiten.Image {
 	if GameConfig.UsePlaceholderSprites {
 		return GenerateEnemyPlaceholder()
 	}
-	
-	// Return default enemy sprite (for now, use idle sprite)
-	// This should be replaced with actual enemy sprites when available
-	return globalIdleSprite
+
+	sm := GetSpriteManager()
+	sprite := sm.GetTileByIndex("enemy", 0)
+	if sprite == nil {
+		return GenerateEnemyPlaceholder()
+	}
+	return sprite
 }
 
 /*
@@ -42,9 +53,9 @@ GetTileSpriteByType returns the appropriate tile sprite based on config.
 If UsePlaceholderSprites is true, returns a placeholder sprite.
 */
 func GetTileSpriteByType(tileType int) *ebiten.Image {
-	if GameConfig.UsePlaceholderSprites {
-		// Map tile types to placeholder types
-		switch tileType {
+	// Map tile types to placeholder types for fallback
+	placeholderForType := func(t int) *ebiten.Image {
+		switch t {
 		case 0x01, 0x02, 0x03: // Ground tiles
 			return GenerateTilePlaceholder(PlaceholderTileGround)
 		case 0x10, 0x11, 0x12: // Wall tiles
@@ -59,7 +70,15 @@ func GetTileSpriteByType(tileType int) *ebiten.Image {
 			return GenerateTilePlaceholder(PlaceholderTileGround)
 		}
 	}
-	
-	// Use existing tile sprite system
-	return GetTileSprite()
+
+	if GameConfig.UsePlaceholderSprites {
+		return placeholderForType(tileType)
+	}
+
+	sm := GetSpriteManager()
+	sprite := sm.GetTileByHex("forest", tileType)
+	if sprite == nil {
+		return placeholderForType(tileType)
+	}
+	return sprite
 }

--- a/engine/state.go
+++ b/engine/state.go
@@ -7,100 +7,39 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/vector"
 )
 
-// Global sprite storage
-var (
-	globalLeftSprite      *ebiten.Image
-	globalRightSprite     *ebiten.Image
-	globalIdleSprite      *ebiten.Image
-	globalBackgroundImage *ebiten.Image
-	globalTileSprite      *ebiten.Image
-	globalTilesSprite     *ebiten.Image
-)
-
 // Global debug rendering settings
 var (
 	showBackground = true
-	showGrid      = false
+	showGrid       = false
 )
 
 /*
-SetGlobalSprites sets the global sprite references for use by all states.
-This function should be called once during initialization to provide 
-all game states with access to the core character and background sprites.
-
-Parameters:
-  - left: Sprite image for left-facing character animation
-  - right: Sprite image for right-facing character animation  
-  - idle: Sprite image for idle/standing character state
-  - background: Background image for rendering behind game elements
-*/
-func SetGlobalSprites(left, right, idle, background *ebiten.Image) {
-	globalLeftSprite = left
-	globalRightSprite = right
-	globalIdleSprite = idle
-	globalBackgroundImage = background
-}
-
-/*
-SetGlobalTileSprites sets the global tile sprite references.
-Used to provide tile rendering capabilities across all game states.
-
-Parameters:
-  - tile: Individual tile sprite image
-  - tiles: Tileset sprite image containing multiple tiles
-*/
-func SetGlobalTileSprites(tile, tiles *ebiten.Image) {
-	globalTileSprite = tile
-	globalTilesSprite = tiles
-}
-
-/*
-GetLeftSprite returns the global left-facing sprite.
-*/
-func GetLeftSprite() *ebiten.Image {
-	return globalLeftSprite
-}
-
-/*
-GetRightSprite returns the global right-facing sprite.
-*/
-func GetRightSprite() *ebiten.Image {
-	return globalRightSprite
-}
-
-/*
-GetIdleSprite returns the global idle sprite.
-*/
-func GetIdleSprite() *ebiten.Image {
-	return globalIdleSprite
-}
-
-/*
-GetBackgroundImage returns the global background image.
+GetBackgroundImage retrieves the background image from the sprite manager.
+Returns nil if the background sheet is not loaded.
 */
 func GetBackgroundImage() *ebiten.Image {
-	return globalBackgroundImage
+	sm := GetSpriteManager()
+	if sheet, ok := sm.sheets["background"]; ok {
+		return sheet.Image
+	}
+	return nil
 }
 
 /*
-GetTileSprite returns the global tile sprite.
+GetTileSprite retrieves the main tile sprite sheet from the sprite manager.
+Returns nil if the sheet is not loaded.
 */
 func GetTileSprite() *ebiten.Image {
-	return globalTileSprite
-}
-
-
-
-/*
-GetTilesSprite returns the global tiles sprite.
-*/
-func GetTilesSprite() *ebiten.Image {
-	return globalTilesSprite
+	sm := GetSpriteManager()
+	if sheet, ok := sm.sheets["forest"]; ok {
+		return sheet.Image
+	}
+	return nil
 }
 
 /*
 ToggleBackground toggles background rendering on/off.
-Useful for debugging and performance testing by removing 
+Useful for debugging and performance testing by removing
 background rendering overhead.
 */
 func ToggleBackground() {
@@ -169,19 +108,19 @@ func DrawGrid(screen *ebiten.Image) {
 
 	screenWidth, screenHeight := screen.Bounds().Dx(), screen.Bounds().Dy()
 	gridColor := color.RGBA{
-		GameConfig.GridColor[0], 
-		GameConfig.GridColor[1], 
-		GameConfig.GridColor[2], 
+		GameConfig.GridColor[0],
+		GameConfig.GridColor[1],
+		GameConfig.GridColor[2],
 		GameConfig.GridColor[3],
 	}
-	
+
 	physicsUnit := GetPhysicsUnit()
-	
+
 	// Draw vertical lines
 	for x := 0; x < screenWidth; x += physicsUnit {
 		vector.StrokeLine(screen, float32(x), 0, float32(x), float32(screenHeight), 1, gridColor, false)
 	}
-	
+
 	// Draw horizontal lines
 	for y := 0; y < screenHeight; y += physicsUnit {
 		vector.StrokeLine(screen, 0, float32(y), float32(screenWidth), float32(y), 1, gridColor, false)
@@ -205,25 +144,25 @@ func DrawGridWithCamera(screen *ebiten.Image, cameraOffsetX, cameraOffsetY float
 
 	screenWidth, screenHeight := screen.Bounds().Dx(), screen.Bounds().Dy()
 	gridColor := color.RGBA{
-		GameConfig.GridColor[0], 
-		GameConfig.GridColor[1], 
-		GameConfig.GridColor[2], 
+		GameConfig.GridColor[0],
+		GameConfig.GridColor[1],
+		GameConfig.GridColor[2],
 		GameConfig.GridColor[3],
 	}
-	
+
 	physicsUnit := GetPhysicsUnit()
-	
+
 	// Calculate grid offset to ensure grid lines align with tiles
 	gridOffsetX := int(cameraOffsetX) % physicsUnit
 	gridOffsetY := int(cameraOffsetY) % physicsUnit
-	
+
 	// Draw vertical lines
 	for x := gridOffsetX; x < screenWidth+physicsUnit; x += physicsUnit {
 		if x >= 0 {
 			vector.StrokeLine(screen, float32(x), 0, float32(x), float32(screenHeight), 1, gridColor, false)
 		}
 	}
-	
+
 	// Draw horizontal lines
 	for y := gridOffsetY; y < screenHeight+physicsUnit; y += physicsUnit {
 		if y >= 0 {


### PR DESCRIPTION
## Summary
- centralize sprite sheet definitions with tile dimensions
- load sprite sheets from config at startup
- retrieve player, enemy, and tile sprites through SpriteManager with placeholder fallback
- drop obsolete global sprite variables

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894eec022a48326ac6b21c0cd220af3