### PR TITLE
Debug escape key game pause

### DIFF
--- a/states/ingame_state.go
+++ b/states/ingame_state.go
@@ -152,10 +152,10 @@ func (ris *InGameState) initializeSystems() {
 	}
 
 	// Register systems with manager
-	ris.systemManager.AddSystem("input", inputSystem)
-	ris.systemManager.AddSystem("physics", physicsSystem)
-	ris.systemManager.AddSystem("camera", cameraSystem)
-	ris.systemManager.AddSystem("room", roomSystem)
+	ris.systemManager.AddSystem("Input", inputSystem)
+	ris.systemManager.AddSystem("Physics", physicsSystem)
+	ris.systemManager.AddSystem("Camera", cameraSystem)
+	ris.systemManager.AddSystem("Room", roomSystem)
 
 	// Set update order: Input -> Room -> Physics -> Camera
 	ris.systemManager.SetUpdateOrder([]string{"Input", "Room", "Physics", "Camera"})


### PR DESCRIPTION
Corrects system registration key casing to re-enable game pausing via the Escape key.

The `InputSystem` was registered with a lowercase key ("input") but looked up with a TitleCase key ("Input"), causing `GetSystem("Input")` to return nil and preventing the pause request from being processed.

---
<a href="https://cursor.com/background-agent?bcId=bc-658dafaa-6aa8-4981-bf6b-4e73abb05f20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-658dafaa-6aa8-4981-bf6b-4e73abb05f20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

