### PR TITLE
Fix sprite, keybindings, and viewport framing

### DIFF
--- a/engine/sprite_helpers.go
+++ b/engine/sprite_helpers.go
@@ -9,26 +9,8 @@ GetPlayerSprite returns the appropriate player sprite based on config.
 If UsePlaceholderSprites is true, returns a placeholder sprite.
 */
 func GetPlayerSprite(facing string) *ebiten.Image {
-	if GameConfig.UsePlaceholderSprites {
-		return GeneratePlayerPlaceholder()
-	}
-
-	sm := GetSpriteManager()
-	var sheetName string
-	switch facing {
-	case "left":
-		sheetName = "player_left"
-	case "right":
-		sheetName = "player_right"
-	default:
-		sheetName = "player_idle"
-	}
-
-	sprite := sm.GetTileByIndex(sheetName, 0)
-	if sprite == nil {
-		return GeneratePlayerPlaceholder()
-	}
-	return sprite
+	// Always use a placeholder for the player to avoid oversized original sprite
+	return GeneratePlayerPlaceholder()
 }
 
 /*


### PR DESCRIPTION
Refactor player sprite rendering, consolidate keybindings, and improve viewport scaling to address visual and control issues.

The original player sprite was oversized, making the player character disproportionately large. Keybindings for debug and settings were scattered, leading to a cluttered control scheme. Additionally, small rooms like the 10x10 grid appeared tiny on screen, wasting space. This PR fixes these by forcing a placeholder sprite, centralizing non-gameplay controls to the Escape menu, and implementing dynamic scaling for small rooms to better utilize screen real estate.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5693f95-a57b-4a39-b696-8cd529ccb4f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5693f95-a57b-4a39-b696-8cd529ccb4f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

