### PR TITLE
Update initial rooms for architecture validation

### DIFF
--- a/resources/rooms/room_transitions.json
+++ b/resources/rooms/room_transitions.json
@@ -1,0 +1,62 @@
+{
+  "rooms": {
+    "main": {
+      "spawn_points": [
+        {"id": "main_spawn", "x": 80, "y": 80}
+      ],
+      "transitions": [
+        {
+          "type": 0,
+          "direction": 2,
+          "trigger_bounds": {"x": 144, "y": 0, "width": 16, "height": 128},
+          "target_room_id": "forest_right",
+          "target_spawn_id": "west",
+          "requires_action": false,
+          "is_enabled": true
+        }
+      ]
+    },
+    "forest_right": {
+      "spawn_points": [
+        {"id": "west", "x": 32, "y": 80},
+        {"id": "east", "x": 128, "y": 80}
+      ],
+      "transitions": [
+        {
+          "type": 0,
+          "direction": 3,
+          "trigger_bounds": {"x": 0, "y": 0, "width": 16, "height": 128},
+          "target_room_id": "main",
+          "target_spawn_id": "main_spawn",
+          "requires_action": false,
+          "is_enabled": true
+        },
+        {
+          "type": 0,
+          "direction": 2,
+          "trigger_bounds": {"x": 144, "y": 0, "width": 16, "height": 128},
+          "target_room_id": "forest_left",
+          "target_spawn_id": "west",
+          "requires_action": false,
+          "is_enabled": true
+        }
+      ]
+    },
+    "forest_left": {
+      "spawn_points": [
+        {"id": "west", "x": 32, "y": 80}
+      ],
+      "transitions": [
+        {
+          "type": 0,
+          "direction": 3,
+          "trigger_bounds": {"x": 0, "y": 0, "width": 16, "height": 128},
+          "target_room_id": "forest_right",
+          "target_spawn_id": "east",
+          "requires_action": false,
+          "is_enabled": true
+        }
+      ]
+    }
+  }
+}

--- a/resources/rooms/room_transitions_embed.go
+++ b/resources/rooms/room_transitions_embed.go
@@ -1,0 +1,9 @@
+package rooms
+
+import (
+	_ "embed"
+)
+
+// RoomTransitionsJSON contains the default room transitions and spawn points configuration.
+//go:embed room_transitions.json
+var RoomTransitionsJSON []byte

--- a/world/transition_loader.go
+++ b/world/transition_loader.go
@@ -31,6 +31,11 @@ func LoadTransitionsFromFile(rtm *RoomTransitionManager, path string) error {
 		return err
 	}
 
+	return LoadTransitionsFromBytes(rtm, data)
+}
+
+// LoadTransitionsFromBytes loads room transitions and spawn points from a JSON byte slice
+func LoadTransitionsFromBytes(rtm *RoomTransitionManager, data []byte) error {
 	var cfg transitionFile
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return err


### PR DESCRIPTION
Implement initial room transitions and world map building for the first three rooms to validate game architecture.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b1501e2-7f6a-490f-baea-79f6e52ba8b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b1501e2-7f6a-490f-baea-79f6e52ba8b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

