### PR TITLE
Fix camera offset for off-screen rendering

### DIFF
--- a/entities/base_enemy.go
+++ b/entities/base_enemy.go
@@ -187,8 +187,8 @@ func (be *BaseEnemy) DrawDebug(screen *ebiten.Image, cameraOffsetX, cameraOffset
 	physicsUnit := engine.GetPhysicsUnit()
 
 	// Calculate render position
-	renderX := float64(be.x)/float64(physicsUnit) - cameraOffsetX
-	renderY := float64(be.y)/float64(physicsUnit) - cameraOffsetY
+	renderX := float64(be.x)/float64(physicsUnit) + cameraOffsetX
+	renderY := float64(be.y)/float64(physicsUnit) + cameraOffsetY
 
 	// Draw bounding box
 	boxColor := color.RGBA{255, 0, 0, 128} // Red for enemies

--- a/states/ingame_state.go
+++ b/states/ingame_state.go
@@ -326,33 +326,33 @@ func (ris *InGameState) Draw(screen *ebiten.Image) {
 	engine.LogDebug("DRAW_LAYER: Room")
 	currentRoom := ris.roomTransitionMgr.GetCurrentRoom()
 	if currentRoom != nil {
-		cameraX, cameraY := ris.camera.GetPosition()
-		currentRoom.DrawWithCamera(screen, float64(cameraX), float64(cameraY))
+		offsetX, offsetY := ris.camera.GetOffset()
+		currentRoom.DrawWithCamera(screen, offsetX, offsetY)
 	}
 
 	engine.LogDebug("DRAW_LAYER: Player")
 	if ris.player != nil {
-		cameraX, cameraY := ris.camera.GetPosition()
-		ris.player.DrawWithCamera(screen, float64(cameraX), float64(cameraY))
+		offsetX, offsetY := ris.camera.GetOffset()
+		ris.player.DrawWithCamera(screen, offsetX, offsetY)
 	}
 
 	engine.LogDebug(fmt.Sprintf("DRAW_LAYER: Enemies (%d)", len(ris.enemies)))
 	// Draw enemies with camera offset
-	cameraX, cameraY := ris.camera.GetPosition()
+	offsetX, offsetY := ris.camera.GetOffset()
 	for _, enemy := range ris.enemies {
-		enemy.DrawWithCamera(screen, float64(cameraX), float64(cameraY))
+		enemy.DrawWithCamera(screen, offsetX, offsetY)
 	}
 
 	if engine.GetGridVisible() {
 		engine.LogDebug("DRAW_LAYER: Grid")
-		cameraX, cameraY := ris.camera.GetPosition()
-		engine.DrawGridWithCamera(screen, float64(cameraX), float64(cameraY))
+		offsetX, offsetY := ris.camera.GetOffset()
+		engine.DrawGridWithCamera(screen, offsetX, offsetY)
 	}
 
 	// Draw viewport frame/borders for small rooms
 	if ris.viewportRenderer != nil {
-		camX, camY := ris.camera.GetPosition()
-		ris.viewportRenderer.SetOffset(float64(camX), float64(camY))
+		offsetX, offsetY := ris.camera.GetOffset()
+		ris.viewportRenderer.SetOffset(offsetX, offsetY)
 		ris.viewportRenderer.DrawFrame(screen)
 	}
 


### PR DESCRIPTION
Fixes off-screen rendering by using `camera.GetOffset()` for drawing game elements.

Previously, the camera's raw world position (`GetPosition()`) was incorrectly used as an offset for rendering, causing game elements (room, player, enemies, grid, viewport frame) to be drawn off-screen. This change utilizes `camera.GetOffset()`, which provides the necessary negative of the camera's position for proper translation, bringing all elements back into view.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5d074a2-01fe-4dd1-8c85-d5edb22a9f73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5d074a2-01fe-4dd1-8c85-d5edb22a9f73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

