### PR TITLE
Enable grid and debug sprites by default

### DIFF
--- a/engine/config.go
+++ b/engine/config.go
@@ -184,9 +184,9 @@ func DefaultConfig() Config {
 		
 		// Debug settings
 		ShowDebugInfo:    true,  // Enable debug info by default for development
-		ShowDebugOverlay: false, // Debug overlay off by default
+		ShowDebugOverlay: true,  // Debug overlay ON by default
 		GridColor:        [4]uint8{128, 128, 128, 64}, // Faint gray grid
-		UsePlaceholderSprites: false, // Use actual sprites by default
+		UsePlaceholderSprites: true, // Use placeholder sprites by default for debugging
 	}
 }
 

--- a/engine/state.go
+++ b/engine/state.go
@@ -10,7 +10,7 @@ import (
 // Global debug rendering settings
 var (
 	showBackground = true
-	showGrid       = false
+	showGrid       = true
 )
 
 /*

--- a/entities/player.go
+++ b/entities/player.go
@@ -280,9 +280,9 @@ func (p *Player) DrawWithCamera(screen *ebiten.Image, cameraOffsetX, cameraOffse
 		// Negative X scale to flip sprite
 		op.GeoM.Scale(-engine.GameConfig.CharScaleFactor, engine.GameConfig.CharScaleFactor)
 	}
-	// Convert player position from physics units to pixels and apply camera offset
-	renderX := float64(p.x)/float64(engine.GetPhysicsUnit()) + cameraOffsetX
-	renderY := float64(p.y)/float64(engine.GetPhysicsUnit()) + cameraOffsetY
+	// Convert player position (already in pixels) and apply camera offset
+	renderX := float64(p.x) + cameraOffsetX
+	renderY := float64(p.y) + cameraOffsetY
 	// When flipped, translate by sprite width to correct position
 	if !p.facingRight {
 		// Assume placeholder/player width of 32 before scaling
@@ -308,11 +308,11 @@ Parameters:
   - cameraOffsetY: Camera Y offset for viewport transformation
 */
 func (p *Player) DrawDebug(screen *ebiten.Image, cameraOffsetX, cameraOffsetY float64) {
-	// Convert player position from physics units to render position
+	// Convert player position (already in pixels) to render position
 	physicsUnit := engine.GetPhysicsUnit()
 	config := &engine.GameConfig.PlayerPhysics
-	renderX := float64(p.x)/float64(physicsUnit) + cameraOffsetX
-	renderY := float64(p.y)/float64(physicsUnit) + cameraOffsetY
+	renderX := float64(p.x) + cameraOffsetX
+	renderY := float64(p.y) + cameraOffsetY
 
 	// Calculate sprite bounds with scaling
 	spriteWidth := float64(config.SpriteWidth) * engine.GameConfig.CharScaleFactor

--- a/states/ingame_state.go
+++ b/states/ingame_state.go
@@ -265,14 +265,14 @@ func (ris *InGameState) updateDebugHUD() {
 			}
 			dh.UpdateRoomInfo(roomInfo)
 
-			// Update player position
+				// Update player position
 			playerX, playerY := ris.player.GetPosition()
 			physicsUnit := engine.GetPhysicsUnit()
-			playerPixelX := float64(playerX) / float64(physicsUnit)
-			playerPixelY := float64(playerY) / float64(physicsUnit)
-			playerTileX := int(playerPixelX / float64(engine.GameConfig.TileSize) / engine.GameConfig.TileScaleFactor)
-			playerTileY := int(playerPixelY / float64(engine.GameConfig.TileSize) / engine.GameConfig.TileScaleFactor)
-			playerPos := fmt.Sprintf("Physics: (%d, %d) | Pixels: (%.1f, %.1f) | Tiles: (%d, %d)",
+			playerPixelX := float64(playerX)
+			playerPixelY := float64(playerY)
+			playerTileX := int(playerPixelX) / physicsUnit
+			playerTileY := int(playerPixelY) / physicsUnit
+			playerPos := fmt.Sprintf("Physics(px): (%d, %d) | Pixels: (%.1f, %.1f) | Tiles: (%d, %d)",
 				playerX, playerY, playerPixelX, playerPixelY, playerTileX, playerTileY)
 			dh.UpdatePlayerPos(playerPos)
 
@@ -334,6 +334,9 @@ func (ris *InGameState) Draw(screen *ebiten.Image) {
 	if ris.player != nil {
 		offsetX, offsetY := ris.camera.GetOffset()
 		ris.player.DrawWithCamera(screen, offsetX, offsetY)
+		if engine.GameConfig.ShowDebugOverlay {
+			ris.player.DrawDebug(screen, offsetX, offsetY)
+		}
 	}
 
 	engine.LogDebug(fmt.Sprintf("DRAW_LAYER: Enemies (%d)", len(ris.enemies)))
@@ -341,6 +344,9 @@ func (ris *InGameState) Draw(screen *ebiten.Image) {
 	offsetX, offsetY := ris.camera.GetOffset()
 	for _, enemy := range ris.enemies {
 		enemy.DrawWithCamera(screen, offsetX, offsetY)
+		if engine.GameConfig.ShowDebugOverlay {
+			enemy.DrawDebug(screen, offsetX, offsetY)
+		}
 	}
 
 	if engine.GetGridVisible() {


### PR DESCRIPTION
Enable debug grid and overlays by default, and fix player rendering coordinates to align with world pixels.

The previous rendering logic incorrectly divided player world coordinates by the `physicsUnit` again, causing a mismatch between the player's actual world position and its on-screen representation. This change ensures that the player's world pixel coordinates are directly used for rendering, making debug visuals and HUD readouts consistent with the grid and tile system.

---
<a href="https://cursor.com/background-agent?bcId=bc-80bed27f-c48a-4722-a682-16e120683f22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80bed27f-c48a-4722-a682-16e120683f22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

