### PR TITLE
Debug player movement after spawn

### DIFF
--- a/entities/player_collision.go
+++ b/entities/player_collision.go
@@ -62,9 +62,9 @@ func (p *Player) CheckTileCollision(tileProvider TileProvider, testX, testY int)
 	// Get physics unit for conversion
 	// Convert collision box to tile coordinates (physics units -> tile indices)
 	leftTile := box.X / engine.GetPhysicsUnit()
-	rightTile := (box.X + box.Width) / engine.GetPhysicsUnit()
+	rightTile := (box.X + box.Width - 1) / engine.GetPhysicsUnit()
 	topTile := box.Y / engine.GetPhysicsUnit()
-	bottomTile := (box.Y + box.Height) / engine.GetPhysicsUnit()
+	bottomTile := (box.Y + box.Height - 1) / engine.GetPhysicsUnit()
 	
 	// Check all tiles the collision box overlaps
 	tiles := tileProvider.GetTiles()

--- a/resources/rooms/room_transitions.json
+++ b/resources/rooms/room_transitions.json
@@ -2,7 +2,7 @@
   "rooms": {
     "main": {
       "spawn_points": [
-        {"id": "main_spawn", "x": 128, "y": 112}
+        {"id": "main_spawn", "x": 128, "y": 96}
       ],
       "transitions": [
         {
@@ -18,8 +18,8 @@
     },
     "forest_right": {
       "spawn_points": [
-        {"id": "west", "x": 32, "y": 112},
-        {"id": "east", "x": 224, "y": 112}
+        {"id": "west", "x": 32, "y": 96},
+        {"id": "east", "x": 224, "y": 96}
       ],
       "transitions": [
         {
@@ -60,7 +60,7 @@
     },
     "safety": {
       "spawn_points": [
-        {"id": "entry", "x": 128, "y": 112}
+        {"id": "entry", "x": 128, "y": 96}
       ],
       "transitions": []
     }


### PR DESCRIPTION
Adjust player spawn Y positions and fix collision calculation to enable player movement.

The player was spawning with their collision box intersecting the solid ground, causing horizontal movement to be blocked. Additionally, an off-by-one error in `player_collision.go` incorrectly counted the next tile for right/bottom edges, leading to false collision positives. These changes ensure the player spawns above ground and collision detection is accurate.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1963c16-61d0-48df-b8a2-c7783679f487">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1963c16-61d0-48df-b8a2-c7783679f487">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

