### PR TITLE
Fix map overlay and minimap bugs

### DIFF
--- a/states/ingame_state.go
+++ b/states/ingame_state.go
@@ -576,17 +576,27 @@ func (ris *InGameState) updateCameraViewport() {
 		if currentRoom != nil {
 			tileMap := currentRoom.GetTileMap()
 			if tileMap != nil {
-							u := engine.GetPhysicsUnit()
-			worldWidth := tileMap.Width * u
-			worldHeight := tileMap.Height * u
-			ris.camera.SetWorldBounds(worldWidth, worldHeight)
-			ris.viewportRenderer.SetWorldBounds(worldWidth, worldHeight)
+				u := engine.GetPhysicsUnit()
+				worldWidth := tileMap.Width * u
+				worldHeight := tileMap.Height * u
+				ris.camera.SetWorldBounds(worldWidth, worldHeight)
+				ris.viewportRenderer.SetWorldBounds(worldWidth, worldHeight)
 
 				// Update camera system
 				if cameraSystem := ris.systemManager.GetSystem("Camera"); cameraSystem != nil {
 					if cs, ok := cameraSystem.(*systems.CameraSystem); ok {
 						cs.SetCurrentRoom(currentRoom)
 					}
+				}
+			}
+		}
+
+		// Re-anchor minimap to top-right with 20px margin
+		if ris.hudManager != nil {
+			if comp := ris.hudManager.GetComponent("minimap"); comp != nil {
+				if mm, ok := comp.(*world.MiniMapRenderer); ok {
+					// Keep default size of 200 used at construction
+					mm.SetPosition(currentWidth-220, 20)
 				}
 			}
 		}

--- a/world/map_overlay.go
+++ b/world/map_overlay.go
@@ -48,7 +48,8 @@ func (zmo *ZoneMapOverlay) Draw(screen interface{}) error {
 	}
 
 	// Darken background
-	w, h := ebiten.WindowSize()
+	b := img.Bounds()
+	w, h := b.Dx(), b.Dy()
 	vector.DrawFilledRect(img, 0, 0, float32(w), float32(h), color.RGBA{0, 0, 0, 180}, false)
 
 	// Map drawing area (padding)
@@ -112,6 +113,7 @@ func (zmo *ZoneMapOverlay) Draw(screen interface{}) error {
 
 	// Connections
 	connColor := color.RGBA{255, 255, 255, 180}
+	drawn := make(map[string]struct{})
 	for fromID, fromRoom := range mapData.DiscoveredRooms {
 		conns := zmo.worldMap.GetRoomConnections(fromID)
 		for _, toID := range conns {
@@ -119,9 +121,19 @@ func (zmo *ZoneMapOverlay) Draw(screen interface{}) error {
 			if !ok {
 				continue
 			}
+			// Avoid drawing both directions
+			a, b := fromID, toID
+			if a > b {
+				a, b = b, a
+			}
+			key := a + "|" + b
+			if _, exists := drawn[key]; exists {
+				continue
+			}
 			x1, y1 := toMini(fromRoom.WorldPos.X, fromRoom.WorldPos.Y)
 			x2, y2 := toMini(toRoom.WorldPos.X, toRoom.WorldPos.Y)
 			vector.StrokeLine(img, x1, y1, x2, y2, 2, connColor, false)
+			drawn[key] = struct{}{}
 		}
 	}
 

--- a/world/worldmap_renderer.go
+++ b/world/worldmap_renderer.go
@@ -63,6 +63,7 @@ func DrawFullWorldMap(img *ebiten.Image, wm *WorldMap, player *entities.Player) 
 	}
 
 	connColor := color.RGBA{255, 255, 255, 180}
+	drawn := make(map[string]struct{})
 	for fromID, fromRoom := range rooms {
 		conns := wm.GetRoomConnections(fromID)
 		for _, toID := range conns {
@@ -70,9 +71,19 @@ func DrawFullWorldMap(img *ebiten.Image, wm *WorldMap, player *entities.Player) 
 			if !ok {
 				continue
 			}
+			// Avoid duplicate undirected edges
+			a, b := fromID, toID
+			if a > b {
+				a, b = b, a
+			}
+			key := a + "|" + b
+			if _, exists := drawn[key]; exists {
+				continue
+			}
 			x1, y1 := toMini(fromRoom.WorldPos.X, fromRoom.WorldPos.Y)
 			x2, y2 := toMini(toRoom.WorldPos.X, toRoom.WorldPos.Y)
 			vector.StrokeLine(img, x1, y1, x2, y2, 2, connColor, false)
+			drawn[key] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
Fixes display bugs in map rendering by anchoring the minimap, correcting zone overlay background, and preventing duplicate connection lines.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac13605b-8dd3-42dc-abde-753cd047067e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac13605b-8dd3-42dc-abde-753cd047067e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

