### PR TITLE
Check parallax behavior for syntax errors

### DIFF
--- a/engine/parallax_renderer.go
+++ b/engine/parallax_renderer.go
@@ -169,7 +169,7 @@ func (pr *ParallaxRenderer) drawLayer(screen *ebiten.Image, layer ParallaxLayer,
 	// Always draw via colorm to respect both alpha and depth color shifts
 	colorOp := &colorm.DrawImageOptions{}
 	colorOp.GeoM = op.GeoM
-	colorOp.Blend = op.Blend
+	colorOp.CompositeMode = op.CompositeMode
 	colorOp.Filter = op.Filter
 	colorm.DrawImage(screen, layerImage, cm, colorOp)
 }


### PR DESCRIPTION
Fix syntax issue in parallax renderer by replacing `Blend` with `CompositeMode` to match ebiten API.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7af63a4-7ec5-4a98-9f6e-beaf6b522c44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7af63a4-7ec5-4a98-9f6e-beaf6b522c44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

