### PR TITLE
Fix tile loading bug

### DIFF
--- a/internal/tiled/loader.go
+++ b/internal/tiled/loader.go
@@ -207,8 +207,19 @@ func extractPortals(layer *TMJLayer) []Portal {
 	return out
 }
 
+// Tiled stores flip flags in the top 3 bits of the GID. NormalizeGID clears those flags.
+const (
+	gidMask uint32 = 0x1FFFFFFF
+)
+
+// NormalizeGID removes flip flags and returns the raw tile id used for tileset indexing.
+func NormalizeGID(gid uint32) uint32 {
+	return gid & gidMask
+}
+
 // Resolve tile properties from a global id. Zero gid returns zero-value props.
 func (lm *LoadedMap) PropertiesForGID(gid uint32) (TileProperties, bool) {
+	gid = NormalizeGID(gid)
 	if gid == 0 {
 		return TileProperties{}, false
 	}
@@ -251,7 +262,7 @@ func (lm *LoadedMap) IsSolidAt(index int) bool {
 		return lm.CollisionLayer.Data[index] != 0
 	}
 	if lm.RenderLayer != nil && index >= 0 && index < len(lm.RenderLayer.Data) {
-		gid := lm.RenderLayer.Data[index]
+		gid := NormalizeGID(lm.RenderLayer.Data[index])
 		if props, ok := lm.PropertiesForGID(gid); ok {
 			return props.Solid
 		}

--- a/world/tiled_room.go
+++ b/world/tiled_room.go
@@ -48,7 +48,7 @@ func NewTiledRoomFromLoadedMap(zoneID string, lm *tiled.LoadedMap) *TiledRoom {
 		for y := 0; y < height; y++ {
 			for x := 0; x < width; x++ {
 				idx := y*width + x
-				gid := lm.RenderLayer.Data[idx]
+				gid := tiled.NormalizeGID(lm.RenderLayer.Data[idx])
 				if gid == 0 {
 					room.tileMap.Tiles[y][x] = -1
 					continue
@@ -71,6 +71,7 @@ func NewTiledRoomFromLoadedMap(zoneID string, lm *tiled.LoadedMap) *TiledRoom {
 // gidToTilesetLocalIndex converts a global id to a 0-based tile index relative to its tileset
 // If tileset cannot be determined, returns -1
 func gidToTilesetLocalIndex(lm *tiled.LoadedMap, gid uint32) int {
+	gid = tiled.NormalizeGID(gid)
 	bestFirst := -1
 	bestIdx := -1
 	for _, ts := range lm.Tilesets {


### PR DESCRIPTION
Normalize Tiled GIDs to strip flip flags, resolving incorrect tile rendering and property lookups for flipped tiles.

Tiled encodes horizontal, vertical, and diagonal flip bits in the high 3 bits of Global IDs (GIDs). Without stripping these flags, tile lookups and sprite indices would fail, causing incorrect or missing tiles when maps used flipped tiles. This fix applies a mask to GIDs before they are used for property lookups or conversion to local tileset indices.

---
<a href="https://cursor.com/background-agent?bcId=bc-6300c167-a268-44c8-8c92-ffedb4cb06fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6300c167-a268-44c8-8c92-ffedb4cb06fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

