### PR TITLE
Update cradle r01 layers and loading

### DIFF
--- a/entities/collision_interface.go
+++ b/entities/collision_interface.go
@@ -13,3 +13,10 @@ type TileProvider interface {
 type CollisionChecker interface {
 	IsSolidTile(tileIndex int) bool
 }
+
+// TileSolidityProvider is an optional interface a room can implement
+// to provide per-cell solidity independent of render-layer indices.
+// The index is the flattened tile cell index: y*width + x.
+type TileSolidityProvider interface {
+	IsSolidAtFlatIndex(index int) bool
+}


### PR DESCRIPTION
Update tile collision detection to use a dedicated collision layer from Tiled maps.

Previously, collision relied on render layer tile properties. This change introduces an explicit collision layer, allowing map designers to define collision separate from rendering, resolving discrepancies. It falls back to render layer properties if no collision layer is present.

---
<a href="https://cursor.com/background-agent?bcId=bc-01ca60d2-dd8e-4b31-bf9c-78cdafcb6a41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01ca60d2-dd8e-4b31-bf9c-78cdafcb6a41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

