### PR TITLE
Investigate missing room logging after tiled refactor

### DIFF
--- a/engine/config.go
+++ b/engine/config.go
@@ -186,11 +186,11 @@ func DefaultConfig() Config {
 		// Debug settings
 		ShowDebugInfo:    true,  // Enable debug info by default for development
 		ShowDebugOverlay: true,  // Debug overlay ON by default
-		GridColor:        [4]uint8{128, 128, 128, 64}, // Faint gray grid
-		UsePlaceholderSprites: true, // Use placeholder sprites by default for debugging
+				GridColor:        [4]uint8{128, 128, 128, 64}, // Faint gray grid
+		UsePlaceholderSprites: false,
 
+		}
 	}
-}
 
 
 


### PR DESCRIPTION
Disable placeholder sprites by default to correctly render Tiled room tiles.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c657db0-e026-4787-8e6c-656d2e117c03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c657db0-e026-4787-8e6c-656d2e117c03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

