### PR TITLE
Fix room tile and viewport sizing

### DIFF
--- a/engine/render_layers.go
+++ b/engine/render_layers.go
@@ -72,19 +72,21 @@ func (vr *ViewportRenderer) DrawFrame(screen *ebiten.Image) {
 		vr.black.Fill(color.Black)
 	}
 
-	// Calculate visible world bounds
+	// Treat offset in screen pixels and world bounds in unscaled pixels (physics units):
+	// convert world bounds to screen space using the current tile scale factor.
+	s := GameConfig.TileScaleFactor
 	worldLeft := vr.offsetX
 	worldTop := vr.offsetY
-	worldRight := worldLeft + float64(vr.worldWidth)
-	worldBottom := worldTop + float64(vr.worldHeight)
-	
+	worldRight := worldLeft + float64(vr.worldWidth)*s
+	worldBottom := worldTop + float64(vr.worldHeight)*s
+
 	// Left border
 	if worldLeft > 0 {
 		opts := &ebiten.DrawImageOptions{}
 		opts.GeoM.Scale(worldLeft, float64(vr.screenHeight))
 		screen.DrawImage(vr.black, opts)
 	}
-	
+
 	// Right border
 	if worldRight < float64(vr.screenWidth) {
 		opts := &ebiten.DrawImageOptions{}
@@ -93,14 +95,14 @@ func (vr *ViewportRenderer) DrawFrame(screen *ebiten.Image) {
 		opts.GeoM.Scale(width, float64(vr.screenHeight))
 		screen.DrawImage(vr.black, opts)
 	}
-	
+
 	// Top border
 	if worldTop > 0 {
 		opts := &ebiten.DrawImageOptions{}
 		opts.GeoM.Scale(float64(vr.screenWidth), worldTop)
 		screen.DrawImage(vr.black, opts)
 	}
-	
+
 	// Bottom border
 	if worldBottom < float64(vr.screenHeight) {
 		opts := &ebiten.DrawImageOptions{}


### PR DESCRIPTION
Ensure engine tile sizes and viewport bounds are correctly set per room by consistently applying `TileScaleFactor` and updating camera bounds on room transitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-28ee622a-9923-4db1-b830-0d03a5e73412">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28ee622a-9923-4db1-b830-0d03a5e73412">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

