### PR TITLE
Fix physics coordinate and pixel scaling

### DIFF
--- a/entities/base_enemy.go
+++ b/entities/base_enemy.go
@@ -117,9 +117,9 @@ Parameters:
   - screen: The target screen/image to render the enemy to
 */
 func (be *BaseEnemy) Draw(screen *ebiten.Image) {
-	// Use enemy sprite (placeholder or actual)
+		// Use enemy sprite (placeholder or actual)
 	sprite := engine.GetEnemySprite()
-
+	
 	// Update scale based on movement direction
 	switch {
 	case be.vx > 0:
@@ -127,12 +127,13 @@ func (be *BaseEnemy) Draw(screen *ebiten.Image) {
 	case be.vx < 0:
 		be.scaleX = -engine.GameConfig.CharScaleFactor // Face left (flip)
 	}
-
-	// Set up drawing options
+	
+	// Set up drawing options (apply world scale)
 	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(be.scaleX, be.scaleY)
-	op.GeoM.Translate(float64(be.x), float64(be.y))
-
+	s := engine.GameConfig.TileScaleFactor
+	op.GeoM.Scale(be.scaleX*s, be.scaleY*s)
+	op.GeoM.Translate(float64(be.x)*s, float64(be.y)*s)
+	
 	// Draw the sprite
 	screen.DrawImage(sprite, op)
 }
@@ -161,10 +162,12 @@ func (be *BaseEnemy) DrawWithCamera(screen *ebiten.Image, cameraOffsetX, cameraO
 
 	// Set up drawing options with camera offset
 	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(be.scaleX, be.scaleY)
-	// Convert enemy position (already pixels) and apply camera offset
-	renderX := float64(be.x) + cameraOffsetX
-	renderY := float64(be.y) + cameraOffsetY
+	// Apply world scale to character scale
+	s := engine.GameConfig.TileScaleFactor
+	op.GeoM.Scale(be.scaleX*s, be.scaleY*s)
+	// Convert world position to screen pixels and apply camera offset
+	renderX := float64(be.x)*s + cameraOffsetX
+	renderY := float64(be.y)*s + cameraOffsetY
 	op.GeoM.Translate(renderX, renderY)
 
 	// Draw the sprite
@@ -192,11 +195,11 @@ func (be *BaseEnemy) DrawDebug(screen *ebiten.Image, cameraOffsetX, cameraOffset
 		boxColor = color.RGBA{0, 255, 0, 128} // Green when on ground
 	}
 
-	// Use default enemy size for bounding box (can be overridden by specific enemies)
-	// These are reasonable defaults based on typical sprite sizes
-	spriteWidth := 32.0 * be.scaleX
-	spriteHeight := 32.0 * be.scaleY
-
+		// Use default enemy size for bounding box in scaled space
+	s := engine.GameConfig.TileScaleFactor
+	spriteWidth := 32.0 * be.scaleX * s
+	spriteHeight := 32.0 * be.scaleY * s
+	
 	// Draw bounding box
 	ebitenutil.DrawRect(screen, renderX, renderY, spriteWidth, spriteHeight, boxColor)
 

--- a/entities/player.go
+++ b/entities/player.go
@@ -270,21 +270,20 @@ func (p *Player) DrawWithCamera(screen *ebiten.Image, cameraOffsetX, cameraOffse
 
 	// Set up drawing options
 	op := &ebiten.DrawImageOptions{}
-	// Flip horizontally based on facing direction
+	// Apply scale: tile/world scale and character scale; flip horizontally if needed
+	s := engine.GameConfig.TileScaleFactor
 	if p.facingRight {
-		op.GeoM.Scale(engine.GameConfig.CharScaleFactor, engine.GameConfig.CharScaleFactor)
+		op.GeoM.Scale(engine.GameConfig.CharScaleFactor*s, engine.GameConfig.CharScaleFactor*s)
 	} else {
-		// Negative X scale to flip sprite
-		op.GeoM.Scale(-engine.GameConfig.CharScaleFactor, engine.GameConfig.CharScaleFactor)
+		op.GeoM.Scale(-engine.GameConfig.CharScaleFactor*s, engine.GameConfig.CharScaleFactor*s)
 	}
-	// Convert player position (already in pixels) and apply camera offset
-	renderX := float64(p.x) + cameraOffsetX
-	renderY := float64(p.y) + cameraOffsetY
+	// Convert world position to screen pixels and apply camera offset
+	renderX := float64(p.x)*s + cameraOffsetX
+	renderY := float64(p.y)*s + cameraOffsetY
 	// When flipped, translate by sprite width to correct position
 	if !p.facingRight {
-		// Assume placeholder/player width of 32 before scaling
 		w := float64(engine.GameConfig.PlayerPhysics.SpriteWidth) * engine.GameConfig.CharScaleFactor
-		op.GeoM.Translate(renderX+w, renderY)
+		op.GeoM.Translate(renderX+w*s, renderY)
 	} else {
 		op.GeoM.Translate(renderX, renderY)
 	}
@@ -305,14 +304,15 @@ Parameters:
   - cameraOffsetY: Camera Y offset for viewport transformation
 */
 func (p *Player) DrawDebug(screen *ebiten.Image, cameraOffsetX, cameraOffsetY float64) {
-	// Convert player position (already in pixels) to render position
+		// Convert player position to scaled screen-space
 	config := &engine.GameConfig.PlayerPhysics
-	renderX := float64(p.x) + cameraOffsetX
-	renderY := float64(p.y) + cameraOffsetY
-
-	// Calculate sprite bounds with scaling
-	spriteWidth := float64(config.SpriteWidth) * engine.GameConfig.CharScaleFactor
-	spriteHeight := float64(config.SpriteHeight) * engine.GameConfig.CharScaleFactor
+	s := engine.GameConfig.TileScaleFactor
+	renderX := float64(p.x)*s + cameraOffsetX
+	renderY := float64(p.y)*s + cameraOffsetY
+	
+	// Calculate sprite bounds in scaled screen-space
+	spriteWidth := float64(config.SpriteWidth) * engine.GameConfig.CharScaleFactor * s
+	spriteHeight := float64(config.SpriteHeight) * engine.GameConfig.CharScaleFactor * s
 
 	// Calculate collision box based on configuration
 	collisionX := renderX + (spriteWidth * config.CollisionBoxOffsetX)

--- a/entities/player_collision.go
+++ b/entities/player_collision.go
@@ -21,7 +21,7 @@ collision box configuration in PlayerPhysicsConfig.
 func (p *Player) GetCollisionBox() CollisionBox {
 	config := &engine.GameConfig.PlayerPhysics
 	
-	// Calculate sprite dimensions in pixels (physics units now equal base pixels)
+	// Calculate sprite dimensions in physics units (render scale does not affect physics)
 	spriteWidth := int(float64(config.SpriteWidth) * engine.GameConfig.CharScaleFactor)
 	spriteHeight := int(float64(config.SpriteHeight) * engine.GameConfig.CharScaleFactor)
 	


### PR DESCRIPTION
Align rendering and debug overlays with `TileScaleFactor` to resolve visual mismatches with the scaled world.

Physics calculations (e.g., collisions, gravity) remain in unscaled base units, ensuring consistent gameplay behavior regardless of the rendering zoom level.

---
<a href="https://cursor.com/background-agent?bcId=bc-94d3c8cb-4060-460f-9037-2f33e36eb159">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94d3c8cb-4060-460f-9037-2f33e36eb159">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

