### PR TITLE
Refactor tiled_room for single responsibility

### DIFF
--- a/world/room_ids.go
+++ b/world/room_ids.go
@@ -1,0 +1,13 @@
+package world
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// RoomIDFromPath creates a stable room id from zone and file path like r01.tmj -> "zone/r01".
+func RoomIDFromPath(zoneName, path string) string {
+	base := filepath.Base(path)
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	return zoneName + "/" + base
+}

--- a/world/tiled_collision.go
+++ b/world/tiled_collision.go
@@ -1,0 +1,63 @@
+package world
+
+import (
+	"sword/engine"
+	"sword/internal/tiled"
+)
+
+// tiledSolidity provides per-cell solidity derived from the Tiled collision layer or tile properties.
+type tiledSolidity struct {
+	loaded *tiled.LoadedMap
+}
+
+func newTiledSolidity(lm *tiled.LoadedMap) *tiledSolidity {
+	return &tiledSolidity{loaded: lm}
+}
+
+func (ts *tiledSolidity) IsSolidAtFlatIndex(index int) bool {
+	if ts.loaded == nil {
+		return false
+	}
+	// Prefer explicit collision layer
+	if ts.loaded.CollisionLayer != nil && index >= 0 && index < len(ts.loaded.CollisionLayer.Data) {
+		return ts.loaded.CollisionLayer.Data[index] != 0
+	}
+	// Fallback: derive from render layer tile properties
+	if ts.loaded.RenderLayer != nil && index >= 0 && index < len(ts.loaded.RenderLayer.Data) {
+		gid := tiled.NormalizeGID(ts.loaded.RenderLayer.Data[index])
+		if props, ok := ts.loaded.PropertiesForGID(gid); ok {
+			return props.Solid
+		}
+	}
+	return false
+}
+
+// findFloorAtX finds the floor Y position at the given X coordinate using the provided solidity function.
+// Returns the Y position in physics units where entities should stand.
+func findFloorAtX(tm *TileMap, isSolidAt func(int) bool, x int) int {
+	if tm == nil {
+		return 0
+	}
+
+	u := engine.GetPhysicsUnit()
+	tileX := x / u
+
+	// Clamp X to valid tile range
+	if tileX < 0 {
+		tileX = 0
+	}
+	if tileX >= tm.Width {
+		tileX = tm.Width - 1
+	}
+
+	// Scan from top to bottom to find first solid tile
+	for tileY := 0; tileY < tm.Height; tileY++ {
+		index := tileY*tm.Width + tileX
+		if isSolidAt != nil && isSolidAt(index) {
+			return tileY * u
+		}
+	}
+
+	// Fallback: bottom of map if no solid tile found
+	return (tm.Height - 1) * u
+}

--- a/world/tiled_map_builder.go
+++ b/world/tiled_map_builder.go
@@ -1,0 +1,54 @@
+package world
+
+import (
+	"sword/internal/tiled"
+)
+
+// buildTileMapFromRenderLayer constructs a TileMap from the Tiled render layer data.
+// It returns the tile map and mapping statistics: number of mapped tiles and number of non-empty tiles.
+func buildTileMapFromRenderLayer(lm *tiled.LoadedMap) (*TileMap, int, int) {
+	width := lm.TMJ.Width
+	height := lm.TMJ.Height
+	tm := NewTileMap(width, height)
+
+	mapped := 0
+	nonEmpty := 0
+
+	if lm.RenderLayer != nil && len(lm.RenderLayer.Data) == width*height {
+		for y := 0; y < height; y++ {
+			for x := 0; x < width; x++ {
+				idx := y*width + x
+				gid := tiled.NormalizeGID(lm.RenderLayer.Data[idx])
+				if gid == 0 {
+					tm.Tiles[y][x] = -1
+					continue
+				}
+				nonEmpty++
+				baseIndex := gidToTilesetLocalIndex(lm, gid)
+				if baseIndex >= 0 {
+					mapped++
+				}
+				tm.Tiles[y][x] = baseIndex
+			}
+		}
+	}
+
+	return tm, mapped, nonEmpty
+}
+
+// gidToTilesetLocalIndex converts a global id to a 0-based tile index relative to its tileset.
+// If tileset cannot be determined, returns -1.
+func gidToTilesetLocalIndex(lm *tiled.LoadedMap, gid uint32) int {
+	gid = tiled.NormalizeGID(gid)
+	bestFirst := -1
+	bestIdx := -1
+	for _, ts := range lm.Tilesets {
+		if int(gid) >= ts.FirstGID {
+			if ts.FirstGID > bestFirst {
+				bestFirst = ts.FirstGID
+				bestIdx = int(gid) - ts.FirstGID
+			}
+		}
+	}
+	return bestIdx
+}

--- a/world/tiled_room.go
+++ b/world/tiled_room.go
@@ -2,8 +2,6 @@ package world
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"sword/engine"
@@ -15,7 +13,9 @@ import (
 // It embeds BaseRoom and stores the parsed loaded map for reference
 type TiledRoom struct {
 	*BaseRoom
-	loaded *tiled.LoadedMap
+	loaded         *tiled.LoadedMap
+	spriteResolver *tileSpriteResolver
+	solidity       *tiledSolidity
 }
 
 // Ensure TiledRoom implements entities.TileSolidityProvider
@@ -27,8 +27,10 @@ func NewTiledRoomFromLoadedMap(zoneID string, lm *tiled.LoadedMap) *TiledRoom {
 	width := lm.TMJ.Width
 	height := lm.TMJ.Height
 	room := &TiledRoom{
-		BaseRoom: NewBaseRoom(zoneID, width, height),
-		loaded:   lm,
+		BaseRoom:       NewBaseRoom(zoneID, width, height),
+		loaded:         lm,
+		spriteResolver: newTileSpriteResolver(lm),
+		solidity:       newTiledSolidity(lm),
 	}
 
 	// Integration logging: tilesets and mapping
@@ -43,146 +45,38 @@ func NewTiledRoomFromLoadedMap(zoneID string, lm *tiled.LoadedMap) *TiledRoom {
 		}
 	}
 
-	// Track mapping coverage
-	mapped := 0
-	nonEmpty := 0
+	// Build the tile map using a focused helper and capture coverage stats
+	tm, mapped, nonEmpty := buildTileMapFromRenderLayer(lm)
+	room.tileMap = tm
 
-	// Populate tiles from render layer data, converting GIDs to 0-based indices
-	if lm.RenderLayer != nil && len(lm.RenderLayer.Data) == width*height {
-		for y := 0; y < height; y++ {
-			for x := 0; x < width; x++ {
-				idx := y*width + x
-				gid := tiled.NormalizeGID(lm.RenderLayer.Data[idx])
-				if gid == 0 {
-					room.tileMap.Tiles[y][x] = -1
-					continue
-				}
-				nonEmpty++
-				baseIndex := gidToTilesetLocalIndex(lm, gid)
-				if baseIndex >= 0 {
-					mapped++
-				}
-				room.tileMap.Tiles[y][x] = baseIndex
-			}
-		}
+	pct := 100.0
+	if nonEmpty > 0 {
+		pct = float64(mapped) * 100.0 / float64(nonEmpty)
 	}
-
-	engine.LogInfo(fmt.Sprintf("Tiled room '%s' tiles mapped: %d/%d (%.1f%%)", zoneID, mapped, nonEmpty, percent(mapped, nonEmpty)))
+	engine.LogInfo(fmt.Sprintf("Tiled room '%s' tiles mapped: %d/%d (%.1f%%)", zoneID, mapped, nonEmpty, pct))
 
 	return room
 }
 
-// gidToTilesetLocalIndex converts a global id to a 0-based tile index relative to its tileset
-// If tileset cannot be determined, returns -1
-func gidToTilesetLocalIndex(lm *tiled.LoadedMap, gid uint32) int {
-	gid = tiled.NormalizeGID(gid)
-	bestFirst := -1
-	bestIdx := -1
-	for _, ts := range lm.Tilesets {
-		if int(gid) >= ts.FirstGID {
-			if ts.FirstGID > bestFirst {
-				bestFirst = ts.FirstGID
-				bestIdx = int(gid) - ts.FirstGID
-			}
-		}
-	}
-	return bestIdx
-}
-
-func percent(a, b int) float64 {
-	if b <= 0 {
-		return 100
-	}
-	return float64(a) * 100.0 / float64(b)
-}
-
 // Draw overrides to render using our tile-based renderer and sprite provider
 func (tr *TiledRoom) Draw(screen *ebiten.Image) {
-	tr.DrawTiles(screen, tr.getTileSprite)
+	tr.DrawTiles(screen, tr.spriteResolver.Resolve)
 }
 
 func (tr *TiledRoom) DrawWithCamera(screen *ebiten.Image, cameraOffsetX, cameraOffsetY float64) {
-	tr.DrawTilesWithCamera(screen, tr.getTileSprite, cameraOffsetX, cameraOffsetY)
-}
-
-// getTileSprite resolves a tile index to an ebiten image using existing engine helpers
-func (tr *TiledRoom) getTileSprite(tileIndex int) *ebiten.Image {
-	if engine.GameConfig.UsePlaceholderSprites {
-		return engine.GetTileSpriteByType(tileIndex)
-	}
-	if sprite := engine.LoadSpriteByHex(tileIndex); sprite != nil {
-		engine.LogDebug(fmt.Sprintf("Sprite resolved via default LoadSpriteByHex idx=%d", tileIndex))
-		return sprite
-	}
-	// If default loading fails, attempt tileset-name-based mapping to sheet
-	if tr.loaded != nil && len(tr.loaded.Tilesets) > 0 {
-		// Prefer last tileset by firstGID proximity to indices we used
-		tsName := tr.loaded.Tilesets[len(tr.loaded.Tilesets)-1].TSX.Name
-		sheet := engine.MapTilesetToSheet(tsName)
-		if sheet != "" {
-			if spr := engine.LoadTileFromSheet(sheet, tileIndex); spr != nil {
-				engine.LogDebug(fmt.Sprintf("Mapped Tiled tileset '%s' -> sheet '%s' for index %d", tsName, sheet, tileIndex))
-				return spr
-			}
-		}
-		engine.LogWarn(fmt.Sprintf("No sprite sheet mapping for tileset '%s' index %d; using fallback tile sheet", tsName, tileIndex))
-	}
-	engine.LogWarn(fmt.Sprintf("Falling back to engine.GetTileSprite for idx=%d", tileIndex))
-	return engine.GetTileSprite()
+	tr.DrawTilesWithCamera(screen, tr.spriteResolver.Resolve, cameraOffsetX, cameraOffsetY)
 }
 
 // IsSolidAtFlatIndex uses the collision layer if present; otherwise falls back to tile properties from render layer
 func (tr *TiledRoom) IsSolidAtFlatIndex(index int) bool {
-	if tr.loaded == nil {
+	if tr.solidity == nil {
 		return false
 	}
-	// Prefer explicit collision layer
-	if tr.loaded.CollisionLayer != nil && index >= 0 && index < len(tr.loaded.CollisionLayer.Data) {
-		return tr.loaded.CollisionLayer.Data[index] != 0
-	}
-	// Fallback: derive from render layer tile properties
-	if tr.loaded.RenderLayer != nil && index >= 0 && index < len(tr.loaded.RenderLayer.Data) {
-		gid := tiled.NormalizeGID(tr.loaded.RenderLayer.Data[index])
-		if props, ok := tr.loaded.PropertiesForGID(gid); ok {
-			return props.Solid
-		}
-	}
-	return false
+	return tr.solidity.IsSolidAtFlatIndex(index)
 }
 
 // FindFloorAtX finds the floor Y position at the given X coordinate.
 // Returns the Y position in physics units where the player should stand.
 func (tr *TiledRoom) FindFloorAtX(x int) int {
-	if tr.tileMap == nil {
-		return 0
-	}
-
-	u := engine.GetPhysicsUnit()
-	tileX := x / u
-
-	// Clamp X to valid tile range
-	if tileX < 0 {
-		tileX = 0
-	}
-	if tileX >= tr.tileMap.Width {
-		tileX = tr.tileMap.Width - 1
-	}
-
-	// Scan from top to bottom to find first solid tile
-	for tileY := 0; tileY < tr.tileMap.Height; tileY++ {
-		index := tileY*tr.tileMap.Width + tileX
-		if tr.IsSolidAtFlatIndex(index) {
-			return tileY * u
-		}
-	}
-
-	// Fallback: bottom of map if no solid tile found
-	return (tr.tileMap.Height - 1) * u
-}
-
-// Utility to create a stable room id from zone and file path like r01.tmj -> "zone/r01"
-func RoomIDFromPath(zoneName, path string) string {
-	base := filepath.Base(path)
-	base = strings.TrimSuffix(base, filepath.Ext(base))
-	return zoneName + "/" + base
+	return findFloorAtX(tr.tileMap, tr.IsSolidAtFlatIndex, x)
 }

--- a/world/tiled_sprite_resolver.go
+++ b/world/tiled_sprite_resolver.go
@@ -1,0 +1,43 @@
+package world
+
+import (
+	"fmt"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"sword/engine"
+	"sword/internal/tiled"
+)
+
+// tileSpriteResolver resolves tile indices to sprites using engine helpers and Tiled tileset info.
+type tileSpriteResolver struct {
+	loaded *tiled.LoadedMap
+}
+
+func newTileSpriteResolver(lm *tiled.LoadedMap) *tileSpriteResolver {
+	return &tileSpriteResolver{loaded: lm}
+}
+
+func (r *tileSpriteResolver) Resolve(tileIndex int) *ebiten.Image {
+	if engine.GameConfig.UsePlaceholderSprites {
+		return engine.GetTileSpriteByType(tileIndex)
+	}
+	if sprite := engine.LoadSpriteByHex(tileIndex); sprite != nil {
+		engine.LogDebug(fmt.Sprintf("Sprite resolved via default LoadSpriteByHex idx=%d", tileIndex))
+		return sprite
+	}
+	// If default loading fails, attempt tileset-name-based mapping to sheet
+	if r.loaded != nil && len(r.loaded.Tilesets) > 0 {
+		// Prefer last tileset by firstGID proximity to indices we used
+		tsName := r.loaded.Tilesets[len(r.loaded.Tilesets)-1].TSX.Name
+		sheet := engine.MapTilesetToSheet(tsName)
+		if sheet != "" {
+			if spr := engine.LoadTileFromSheet(sheet, tileIndex); spr != nil {
+				engine.LogDebug(fmt.Sprintf("Mapped Tiled tileset '%s' -> sheet '%s' for index %d", tsName, sheet, tileIndex))
+				return spr
+			}
+		}
+		engine.LogWarn(fmt.Sprintf("No sprite sheet mapping for tileset '%s' index %d; using fallback tile sheet", tsName, tileIndex))
+	}
+	engine.LogWarn(fmt.Sprintf("Falling back to engine.GetTileSprite for idx=%d", tileIndex))
+	return engine.GetTileSprite()
+}


### PR DESCRIPTION
Refactor `TiledRoom` to delegate responsibilities to dedicated components, improving readability and adherence to the single responsibility principle.

---
<a href="https://cursor.com/background-agent?bcId=bc-0aff8859-2194-4d38-9339-3e47d27bf277">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0aff8859-2194-4d38-9339-3e47d27bf277">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

