### PR TITLE
Expand right portal trigger width in cradle map

### DIFF
--- a/assets/zones/cradle/r01.tmj
+++ b/assets/zones/cradle/r01.tmj
@@ -76,7 +76,7 @@
                  "rotation":0,
                  "type":"portal",
                  "visible":true,
-                 "width":4,
+                 "width":16,
                  "x":252,
                  "y":80
                 }, 


### PR DESCRIPTION
## Summary
- increase width of the `right` portal in `cradle/r01.tmj` so the trigger covers 16px instead of 4px

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a14d5b11b48326a798dcc15eaff73e