### PR TITLE
Fix tiled collision and room transitions

### DIFF
--- a/entities/player_collision.go
+++ b/entities/player_collision.go
@@ -23,8 +23,8 @@ func (p *Player) GetCollisionBox() CollisionBox {
 	config := &engine.GameConfig.PlayerPhysics
 	
 	// Calculate sprite dimensions in physics units (render scale does not affect physics)
-	spriteWidth := int(float64(config.SpriteWidth) * engine.GameConfig.CharScaleFactor)
-	spriteHeight := int(float64(config.SpriteHeight) * engine.GameConfig.CharScaleFactor)
+	spriteWidth := config.SpriteWidth
+	spriteHeight := config.SpriteHeight
 	
 	// Calculate collision box based on configuration
 	offsetX := int(float64(spriteWidth) * config.CollisionBoxOffsetX)
@@ -52,6 +52,10 @@ Parameters:
 func (p *Player) CheckTileCollision(tileProvider TileProvider, testX, testY int) bool {
 	// Use collision service for better separation of concerns
 	if p.collisionService == nil {
+		p.collisionService = NewCollisionService(tileProvider)
+	}
+	// Recreate service if provider changed (e.g., room transition)
+	if !p.collisionService.IsForProvider(tileProvider) {
 		p.collisionService = NewCollisionService(tileProvider)
 	}
 	

--- a/world/room_transition.go
+++ b/world/room_transition.go
@@ -312,8 +312,8 @@ func (rtm *RoomTransitionManager) findSafeSpawnPosition(player *entities.Player,
 			return 0, false
 		}
 		cfg := &engine.GameConfig.PlayerPhysics
-		// Collision box dimensions in physics units (char scale applies to sprite dims)
-		spriteH := int(float64(cfg.SpriteHeight) * engine.GameConfig.CharScaleFactor)
+		// Collision box dimensions in physics units
+		spriteH := cfg.SpriteHeight
 		offsetY := int(float64(spriteH) * cfg.CollisionBoxOffsetY)
 		boxH := int(float64(spriteH) * cfg.CollisionBoxHeight)
 		// Position top-left of sprite such that bottom of collision box is exactly at floor


### PR DESCRIPTION
Fix player collision and spawn positioning to use physics units, and ensure collision service re-initializes on room changes.

The previous PR inadvertently caused player collision boxes and spawn positions to scale with the render factor (`CharScaleFactor`) instead of remaining in consistent physics units. This led to incorrect collision detection against Tiled collision layers and misaligned player spawns after room transitions. This PR corrects these calculations and ensures the collision service properly adapts to new room tile providers.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc0da59e-50b5-4843-bc41-ba947ac9c3ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc0da59e-50b5-4843-bc41-ba947ac9c3ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

